### PR TITLE
Fix background color in dark mode

### DIFF
--- a/src/viewer/App.scss
+++ b/src/viewer/App.scss
@@ -54,6 +54,7 @@
   font-size: 12px;
   color: var(--base-text-color);
   overflow: hidden;
+  background-color: var(--main-background-color);
 }
 .LeftPanel {
   border-right: 1px solid #ccc;


### PR DESCRIPTION
Fixed background color in dark mode.

### Motivation:

I use chrome with dark mode. Background color and text in dev tools is white, so i cant see frame content:
![devtools](https://user-images.githubusercontent.com/34436776/146792827-b9c2f6e8-1ba9-4aa4-aa22-b2d5e1ba8f87.PNG)
![devtools2](https://user-images.githubusercontent.com/34436776/146792941-458e8ba0-6b95-4515-9ddd-1a86712211df.PNG)


### Modifications:

Added one css line.

### Result:

![devtools fixed](https://user-images.githubusercontent.com/34436776/146792991-447b1f54-3057-4dad-ad97-64394e394b77.PNG)

