### PR TITLE
Remove line breaks from ASCII section when copying

### DIFF
--- a/src/viewer/App.scss
+++ b/src/viewer/App.scss
@@ -223,11 +223,12 @@
   font-family: 'Consolas', 'Courier', monospace;
   font-size: 16px;
   white-space: nowrap;
-  ul {
-    list-style-type: none;
+  div {
     margin: 0;
     padding: 0;
     display: inline-block;
+    // Align the line/hex/ascii block lines by forcing the text to break on <wbr>
+    width: min-content;
   }
   .line-numbers {
     color: var(--grey-text-color);

--- a/src/viewer/App.tsx
+++ b/src/viewer/App.tsx
@@ -113,8 +113,8 @@ interface RSocketFrameProps {
 }
 
 class RSocketFrame extends React.Component<RSocketFrameProps, any> {
-  private hexView: HTMLUListElement | null = null;
-  private asciiView: HTMLUListElement | null = null;
+  private hexView: HTMLDivElement | null = null;
+  private asciiView: HTMLDivElement | null = null;
 
   render() {
     const {frame, data, className, ...props} = this.props;
@@ -126,14 +126,15 @@ class RSocketFrame extends React.Component<RSocketFrameProps, any> {
     const dot = ".".charCodeAt(0);
     for (let pos = 0; pos < data.length; pos += 16) {
       const row = [...(data as any).subarray(pos, pos + 16)];
-      lineNumbers.push(<li key={pos}>{pos.toString(16).padStart(numDigits, '0')}:</li>);
-      hexView.push(<li key={pos}>
+      // Use <wbr> to add line breaks but keep ASCII text copyable (<wbr> are not included in copied text)
+      lineNumbers.push(<span key={pos}>{pos.toString(16).padStart(numDigits, '0')}:<wbr/></span>);
+      hexView.push(<span key={pos}>
         {row.map((byte: number, i) => <span key={i}>{byte.toString(16).padStart(2, '0')}</span>)}
         {row.length < 16 && [...Array(16 - row.length)].map((nil, i) => <span key={i}
                                                                               className="padding">{"  "}</span>)}
-      </li>);
-      asciiView.push(<li
-        key={pos}>{String.fromCharCode(...row.map(byte => byte >= 32 && byte <= 126 ? byte : dot))}</li>);
+        <wbr/></span>);
+      asciiView.push(<span
+          key={pos}>{String.fromCharCode(...row.map(byte => byte >= 32 && byte <= 126 ? byte : dot))}<wbr/></span>);
     }
     let jsonData: any;
     try {
@@ -167,15 +168,15 @@ class RSocketFrame extends React.Component<RSocketFrameProps, any> {
         {jsonField}
         <hr/>
         <div className={classNames(className, "RSocketFrame")} {...props}>
-          <ul className="line-numbers">
+          <div className="line-numbers">
             {lineNumbers}
-          </ul>
-          <ul className="hex-view" ref={node => this.hexView = node}>
+          </div>
+          <div className="hex-view" ref={node => this.hexView = node}>
             {hexView}
-          </ul>
-          <ul className="ascii-view" ref={node => this.asciiView = node}>
+          </div>
+          <div className="ascii-view" ref={node => this.asciiView = node}>
             {asciiView}
-          </ul>
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
### Motivation:

See https://github.com/rsocket/rsocket-chrome-devtools/issues/35

### Modifications:

Replace the use of `<li>` for each line in the line/hex/ASCII views with `<wbr>`.

### Result:

The text still renders line wrapped (and the lines in the hex/ASCII sections still line up) but now when copying the ASCII text to the clipboard, there are no more line breaks.

Before:

<img width="1264" alt="Screenshot 2024-01-30 at 3 49 10 pm old" src="https://github.com/rsocket/rsocket-chrome-devtools/assets/16778/76f2396e-ea06-4c81-ba80-8626555b9fe1">

Copies as:

```
{"A?":"A",
"A":{"A":{"V":{"
A":[{"A?":"E","A
":{"A":{"B":{"_s
4R8betoCM8urxV":
{"A":{"A":35},"B
":{"A":34}}}}}}]
}}},"B":10}
```

After:

<img width="1258" alt="Screenshot 2024-01-30 at 3 48 13 pm new" src="https://github.com/rsocket/rsocket-chrome-devtools/assets/16778/1d5ace45-f1ae-4b07-86c1-fb7bf3fb17dd">

Copies as:

```
{"A?":"A","A":{"A":{"V":{"A":[{"A?":"E","A":{"A":{"B":{"zFggAtk4r2oWM19F":{"A":{"A":16},"B":{"A":15}}}}}}]}}},"B":7}
```